### PR TITLE
chore: Simplify GitHub Actions publish workflow triggers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      - 'v*'
-  pull_request:
-    branches:
-      - master
 
 # Add permissions block at workflow level
 permissions:


### PR DESCRIPTION
Remove unnecessary trigger conditions for pull requests and tags, focusing only on master branch pushes
