### PR TITLE
chore: Streamline semantic-release workflow configuration

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
 
-# Add permissions block at workflow level
 permissions:
   contents: write
   issues: write
@@ -16,7 +15,6 @@ env:
   RUST_VERSION: stable
 
 jobs:
-  # This job determines the next version using conventional commits and semantic versioning
   semantic-versioning:
     name: Determine version
     runs-on: ubuntu-latest
@@ -30,7 +28,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          # This ensures the checkout action uses a token with sufficient permissions
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
@@ -38,20 +35,18 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install conventionalcommits dependencies
-        run: |
-          npm install -g conventional-changelog-conventionalcommits @semantic-release/commit-analyzer @semantic-release/release-notes-generator @semantic-release/changelog @semantic-release/git @semantic-release/github
-
       - name: Semantic Release
         id: semantic
         uses: cycjimmy/semantic-release-action@v4
         with:
           semantic_version: 19
-          branches: |
-            [
-              'master'
-            ]
-        
+          branches: master
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/changelog
+            @semantic-release/git
+            @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Simplify publish workflow by:
- Removing redundant comments
- Consolidating semantic-release plugin installation
- Directly specifying 'master' branch instead of array
- Inline extra plugin configuration
